### PR TITLE
Servlets do not working correctly when run with main class

### DIFF
--- a/base-filesystem/bin/start-interlok
+++ b/base-filesystem/bin/start-interlok
@@ -180,7 +180,7 @@ save () {
 APP_ARGS=`save "$@"`
 
 # Collect all arguments for the java command, following the shell quoting and substitution rules
-eval set -- $DEFAULT_JVM_OPTS $JAVA_OPTS $INTERLOK_OPTS -classpath "\"$CLASSPATH\"" com.adaptris.interlok.boot.InterlokLauncher "$APP_ARGS"
+eval set -- $DEFAULT_JVM_OPTS $JAVA_OPTS $INTERLOK_OPTS -classpath "\"$CLASSPATH\"" -jar ../lib/interlok-boot.jar "$APP_ARGS"
 
 # Go to app home dir
 cd "$APP_HOME"

--- a/base-filesystem/bin/start-interlok.bat
+++ b/base-filesystem/bin/start-interlok.bat
@@ -72,7 +72,7 @@ set CLASSPATH=%APP_HOME%\lib\interlok-boot.jar
 @rem Go to app home dir
 cd %APP_HOME%
 @rem Execute Interlok
-"%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %INTERLOK_OPTS%  -classpath "%CLASSPATH%" com.adaptris.interlok.boot.InterlokLauncher %*
+"%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %INTERLOK_OPTS%  -classpath "%CLASSPATH%" -jar ../lib/interlok-boot.jar %*
 
 :end
 @rem End local scope for the variables with windows NT shell


### PR DESCRIPTION
## Motivation

We found an issue when running components like health-check if you were to start Interlok with the main-class.  It's something to do with the way Jetty carries over any Add-Opens settings in the manifest files.  Essentially the health-check component would complain that certain libraries do not have access to other base java libraries.

## Modification

The installer start scripts now no longer use the main cl;ass in the JAVA.exe command to launch interlok, the scripts now use -jar interlok-boot.jar, which seems to solve the Add-Opens issues.

