### PR TITLE
INTERLOK-4428: Update java command to use -jar

### DIFF
--- a/base-filesystem/bin/start-interlok
+++ b/base-filesystem/bin/start-interlok
@@ -180,7 +180,7 @@ save () {
 APP_ARGS=`save "$@"`
 
 # Collect all arguments for the java command, following the shell quoting and substitution rules
-eval set -- $DEFAULT_JVM_OPTS $JAVA_OPTS $INTERLOK_OPTS -classpath "\"$CLASSPATH\"" com.adaptris.interlok.boot.InterlokLauncher "$APP_ARGS"
+eval set -- $DEFAULT_JVM_OPTS $JAVA_OPTS $INTERLOK_OPTS -jar $APP_HOME/lib/interlok-boot.jar "$APP_ARGS"
 
 # Go to app home dir
 cd "$APP_HOME"

--- a/base-filesystem/bin/start-interlok.bat
+++ b/base-filesystem/bin/start-interlok.bat
@@ -72,7 +72,7 @@ set CLASSPATH=%APP_HOME%\lib\interlok-boot.jar
 @rem Go to app home dir
 cd %APP_HOME%
 @rem Execute Interlok
-"%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %INTERLOK_OPTS%  -classpath "%CLASSPATH%" com.adaptris.interlok.boot.InterlokLauncher %*
+"%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %INTERLOK_OPTS% -jar %APP_HOME%/lib/interlok-boot.jar  %*
 
 :end
 @rem End local scope for the variables with windows NT shell


### PR DESCRIPTION
## Motivation

https://adaptris.atlassian.net/browse/INTERLOK-4428

## Modification

start-interlok command script to use -jar

## PR Checklist

- [x] been self-reviewed.
- [ ] Added javadocs for most classes and all non-trivial methods
- [ ] Added supporting annotations (like @XStreamAlias / @ComponentProfile)
- [ ] Added DefaultValue annotation when there is a default value (e.g. @DefaultValue('true'))
- [ ] Added validation annotation (@NotNull...) when required and add @Valid when nested class has some validation
- [ ] Checked that @NotNull and @NotBlank annotations have a meaningful message when appropriate.
- [ ] Checked that new 3rd party dependencies are appropriately licensed
- [ ] Added comments explaining the "why" and the intent of the code wherever it would not be obvious for an unfamiliar reader
- [ ] Added unit tests or modified existing tests to cover new code paths
- [ ] Tested new/updated components in the UI and at runtime in an Interlok instance
- [ ] Reviewed java class members so that missing annotations are added (InputFieldDefault/ComponentProfile etc)
- [ ] Checked that javadoc generation doesn't report errors
- [ ] Checked the display of the component in the UI
- [ ] Remove any config/license annotations
- [ ] Check the gradle build file to make sure the dependencies section is more explicit "implementation/api".

## Result

Health check component will work

## Testing

Update the adapter start-interlok script with the one in this change, ensure the health check component is configured, start up the adapter and hit the health check URL to see if any exceptions occur.
